### PR TITLE
Add customizable presentation params and simple credential UI

### DIFF
--- a/app/routers/presentations2.py
+++ b/app/routers/presentations2.py
@@ -67,37 +67,46 @@ def load_wallet_credentials(holder_did: str, password: str) -> list[str]:
     return out
 
 # ===== Generar openid:// “estático” para VP =====
-def build_openid_vp():
+def build_openid_vp(aud: str = "openid://", nonce: str | None = None):
     state = secrets.token_urlsafe(16)
-    nonce = secrets.token_urlsafe(16)
+    nonce = nonce or secrets.token_urlsafe(16)
     post_endpoint = cfg("RESPONSE_URI") or (base_url() + "/verifier/response")
-    request_uri = (base_url()
-                   + "/request?"
-                   + urllib.parse.urlencode({
-                        "client_id": base_url(),
-                        "redirect_uri": post_endpoint,
-                        "response_type": "vp_token",
-                        "response_mode": "direct_post",
-                        "scope": "openid",
-                        "state": state,
-                        "nonce": nonce,
-                        "aud": "openid://",
-                    }))
-    openid_url = ("openid://?"
-                  + urllib.parse.urlencode({
-                        "client_id": base_url(),
-                        "redirect_uri": post_endpoint,
-                        "response_type": "vp_token",
-                        "response_mode": "direct_post",
-                        "scope": "openid",
-                        "state": state,
-                        "nonce": nonce,
-                        "request_uri": request_uri,
-                  }))
+    request_uri = (
+        base_url()
+        + "/request?"
+        + urllib.parse.urlencode(
+            {
+                "client_id": base_url(),
+                "redirect_uri": post_endpoint,
+                "response_type": "vp_token",
+                "response_mode": "direct_post",
+                "scope": "openid",
+                "state": state,
+                "nonce": nonce,
+                "aud": aud,
+            }
+        )
+    )
+    openid_url = (
+        "openid://?"
+        + urllib.parse.urlencode(
+            {
+                "client_id": base_url(),
+                "redirect_uri": post_endpoint,
+                "response_type": "vp_token",
+                "response_mode": "direct_post",
+                "scope": "openid",
+                "state": state,
+                "nonce": nonce,
+                "request_uri": request_uri,
+            }
+        )
+    )
     return {
         "openid_url": openid_url,
         "state": state,
         "nonce": nonce,
+        "aud": aud,
         "redirect_uri": post_endpoint,
         "request_uri": request_uri,
     }
@@ -144,6 +153,8 @@ async def wallet_present(request: Request):
       "holder_did": "did:jwk:...",
       "password": "default",
       "select": [0,1,2],
+      "aud": "https://verifier.example",  # opcional
+      "nonce": "xyz",                     # opcional
       "send": true   # opcional: si true, hace POST a /verifier/response
     }
     """
@@ -152,9 +163,11 @@ async def wallet_present(request: Request):
     password = body.get("password", "default")
     select = body.get("select", [0])
     do_send = bool(body.get("send", False))
+    aud = body.get("aud", "openid://")
+    nonce = body.get("nonce")
 
     # 1) Abrimos un “openid://” de VP local
-    auth = build_openid_vp()
+    auth = build_openid_vp(aud=aud, nonce=nonce)
 
     # 2) Cargamos y seleccionamos VCs
     all_vcs = load_wallet_credentials(holder_did or "", password)
@@ -171,7 +184,7 @@ async def wallet_present(request: Request):
     priv = load_or_create_holder_key()
     did_local = holder_did or holder_did_from_key(priv)
     vp_jwt, vp_payload = make_vp_jwt(
-        vc_jwts=chosen, iss_did=did_local, aud="openid://", nonce=auth["nonce"]
+        vc_jwts=chosen, iss_did=did_local, aud=aud, nonce=auth["nonce"]
     )
     pres_sub = build_presentation_submission(len(chosen))
 
@@ -200,6 +213,7 @@ async def wallet_present(request: Request):
         "openid_url": auth["openid_url"],
         "state": auth["state"],
         "nonce": auth["nonce"],
+        "aud": auth.get("aud"),
         "vp_jwt": vp_jwt,
         "vp_payload": vp_payload,
         "presentation_submission": pres_sub,

--- a/frontend/holder-app/index.html
+++ b/frontend/holder-app/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <title>Wallet Holder</title>
+</head>
+<body>
+  <h1>Credenciales</h1>
+  <div>
+    <label>DID: <input id="holderDid" /></label>
+    <label>Contraseña: <input id="password" type="password" /></label>
+    <button onclick="loadCredentials()">Cargar</button>
+  </div>
+  <ul id="credList"></ul>
+  <div id="selected"></div>
+  <pre id="details"></pre>
+  <h2>Presentación</h2>
+  <div>
+    <label>aud: <input id="aud" /></label>
+    <label>nonce: <input id="nonce" /></label>
+    <label>send: <input type="checkbox" id="send" /></label>
+    <button onclick="present()">Presentar</button>
+  </div>
+  <h3>VP JWT</h3>
+  <pre id="vpjwt"></pre>
+  <div id="postresult"></div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/frontend/holder-app/script.js
+++ b/frontend/holder-app/script.js
@@ -1,0 +1,85 @@
+// Basic viewer/presenter for credentials
+let credentials = [];
+let selectedIndex = null;
+
+function loadCredentials() {
+  const holderDid = document.getElementById('holderDid').value;
+  const password = document.getElementById('password').value;
+  fetch('/holder/credentials', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ holder_did: holderDid, password })
+  })
+    .then(r => r.json())
+    .then(data => {
+      credentials = data.credentials || [];
+      const list = document.getElementById('credList');
+      list.innerHTML = '';
+      credentials.forEach((_, idx) => {
+        const li = document.createElement('li');
+        li.textContent = `Credencial ${idx} `;
+        const btnSel = document.createElement('button');
+        btnSel.textContent = 'Seleccionar';
+        btnSel.onclick = () => selectCredential(idx);
+        const btnDet = document.createElement('button');
+        btnDet.textContent = 'Detalles';
+        btnDet.onclick = () => viewDetails(idx);
+        li.appendChild(btnSel);
+        li.appendChild(btnDet);
+        list.appendChild(li);
+      });
+    });
+}
+
+function selectCredential(i) {
+  selectedIndex = i;
+  document.getElementById('selected').textContent = 'Seleccionada credencial ' + i;
+  viewDetails(i);
+}
+
+function viewDetails(i) {
+  const holderDid = document.getElementById('holderDid').value;
+  const password = document.getElementById('password').value;
+  fetch('/holder/decode-credential', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ holder_did: holderDid, password, index: i })
+  })
+    .then(r => r.json())
+    .then(data => {
+      document.getElementById('details').textContent = JSON.stringify(data, null, 2);
+    });
+}
+
+function present() {
+  if (selectedIndex === null) {
+    alert('Seleccione una credencial');
+    return;
+  }
+  const holderDid = document.getElementById('holderDid').value;
+  const password = document.getElementById('password').value;
+  const aud = document.getElementById('aud').value || 'openid://';
+  const nonce = document.getElementById('nonce').value || crypto.randomUUID();
+  const send = document.getElementById('send').checked;
+  fetch('/wallet/present', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      holder_did: holderDid,
+      password,
+      select: [selectedIndex],
+      aud,
+      nonce,
+      send
+    })
+  })
+    .then(r => r.json())
+    .then(data => {
+      document.getElementById('vpjwt').textContent = data.vp_jwt || '';
+      if (send) {
+        document.getElementById('postresult').textContent = 'POST status: ' + data.post_status;
+      } else {
+        document.getElementById('postresult').textContent = '';
+      }
+    });
+}


### PR DESCRIPTION
## Summary
- allow `/wallet/present` to receive custom `aud` and `nonce` values
- expose POST result and generated `vp_jwt` in response
- provide minimal frontend to inspect credentials and trigger presentation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b852a7297483328c14570a3a3e515e