### PR TITLE
Require explicit password with validation

### DIFF
--- a/frontend/holder-app/src/services/api.ts
+++ b/frontend/holder-app/src/services/api.ts
@@ -4,6 +4,15 @@ const api = axios.create({
   baseURL: import.meta.env.VITE_FASTAPI_URL || 'http://localhost:8000',
 });
 
+function assertPassword(password: string) {
+  if (!password) {
+    throw new Error('Password is required');
+  }
+  if (password.length < 8) {
+    throw new Error('Password must be at least 8 characters long');
+  }
+}
+
 export async function createDid() {
   const { data } = await api.post('/holder/create-did-jwk');
   return data;
@@ -11,6 +20,7 @@ export async function createDid() {
 
 export async function receiveCredential(payload: {credential_offer_uri: string; holder_did: string; password: string;}) {
   try {
+    assertPassword(payload.password);
     const { data } = await api.post('/holder/receive-oid4vc', payload);
     return data;
   } catch (e: any) {
@@ -20,6 +30,7 @@ export async function receiveCredential(payload: {credential_offer_uri: string; 
 
 export async function listCredentials(payload: {holder_did: string; password: string;}) {
   try {
+    assertPassword(payload.password);
     const { data } = await api.post('/holder/credentials', payload);
     return data;
   } catch (e: any) {
@@ -29,6 +40,7 @@ export async function listCredentials(payload: {holder_did: string; password: st
 
 export async function deleteCredential(payload: {holder_did: string; password: string; index: number;}) {
   try {
+    assertPassword(payload.password);
     const { data } = await api.post('/holder/delete-credential', payload);
     return data;
   } catch (e: any) {
@@ -38,6 +50,7 @@ export async function deleteCredential(payload: {holder_did: string; password: s
 
 export async function presentCredential(payload: {holder_did: string; password: string; index: number; aud: string; nonce: string;}) {
   try {
+    assertPassword(payload.password);
     const { data } = await api.post('/holder/present-credential-jwt', payload);
     return data;
   } catch (e: any) {

--- a/frontend/holder-app/src/store/useWalletStore.ts
+++ b/frontend/holder-app/src/store/useWalletStore.ts
@@ -9,7 +9,8 @@ interface WalletState {
 
 export const useWalletStore = create<WalletState>((set) => ({
   holderDid: localStorage.getItem('holderDid') || '',
-  password: 'default',
+  // Start with an empty password so the user must provide one
+  password: '',
   setHolderDid: (did) => {
     localStorage.setItem('holderDid', did);
     set({ holderDid: did });


### PR DESCRIPTION
## Summary
- remove default wallet password and force user input
- validate password presence and length on client API calls
- require password in holder endpoints with clear errors

## Testing
- `pytest`
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b85a9874708332b0ace9fd28697cb4